### PR TITLE
Add dark buttons

### DIFF
--- a/sass/_options.scss
+++ b/sass/_options.scss
@@ -136,7 +136,6 @@ body {
 		border-radius: 3px;
 		outline: none;
 		border: none;
-		color: $font-secondary !important;
 		border-radius: 2px;
 		background-color: $font_primary;
 		opacity: 0.7;

--- a/sass/_playmidnight.scss
+++ b/sass/_playmidnight.scss
@@ -201,6 +201,40 @@ body {
 
 
 
+// Buttons
+.button:not(.primary) {
+	background-color: #43474E !important;
+	color: #ccc !important;
+}
+
+.button:not(.primary):hover,
+.button:not(.primary):focus {
+	background-color: #2C2C2C !important;
+	color: #ccc !important;
+}
+
+#music-content .button:not(.primary) {
+	background-color: #2C2C2C !important;
+}
+
+#music-content .button:not(.primary):hover,
+#music-content .button:not(.primary):focus {
+	background-color: #43474E !important;
+}
+
+.button:not(.primary) .icon,
+.button:not(.primary) img,
+.button:not(.primary) #extra-links-anchor,
+.button:not(.primary) .extra-links-dropdown {
+	-webkit-filter: invert(100%); /* Invert dark icons -> light icons */
+}
+
+.button:not(.primary):active {
+	box-shadow: inset 0 2px 0 rgba(221, 221, 221, 0.15) !important;
+}
+
+
+
 // Main Content
 #content, #main, .g-content, div.nerd-panel, #music-content {
 	background-color: $primary;


### PR DESCRIPTION
Adds a dark background to buttons and turns light sprites to dark ones with `-webkit-filter: invert(100%);`
Also removes the now-unnecessary `color` property from `#play-midnight-options button`.

![Screenshot 1](http://i.imgur.com/8REU7SL.png)

![Screenshot 2](http://i.imgur.com/M2sxv3K.png)

![Screenshot 3](http://i.imgur.com/iQiphKG.png)

__Note:__ The compiled CSS files aren't included, as I thought you might want to compile them yourself.