### PR TITLE
Make default album and artist cards dark

### DIFF
--- a/sass/_playmidnight.scss
+++ b/sass/_playmidnight.scss
@@ -239,6 +239,12 @@ body {
 		background: transparent;
 		color: #600;
 	}
+
+	img[src$="default_artist_art.png"],
+	img[src$="default_album_art_big_card.png"],
+	img[src$="default_album_art_song_row.png"] {
+		-webkit-filter: invert(100%);
+	}
 }
 
 

--- a/sass/_playmidnight.scss
+++ b/sass/_playmidnight.scss
@@ -242,7 +242,8 @@ body {
 
 	img[src$="default_artist_art.png"],
 	img[src$="default_album_art_big_card.png"],
-	img[src$="default_album_art_song_row.png"] {
+	img[src$="default_album_art_song_row.png"],
+	img[src$="default_album_med.png"] {
 		-webkit-filter: invert(100%);
 	}
 }


### PR DESCRIPTION
Uses `-webkit-filter: invert(100%);` to turn the originally light "default album art" and "default artist art" images to dark ones.

![Screenshot 1](http://i.imgur.com/c26RX25.png)

![Screenshot 2](http://i.imgur.com/P7pzzsR.png)

![Screenshot 3](http://i.imgur.com/ZPBVtSX.png)

__Note:__ The compiled CSS files aren't included, as I thought you might want to compile them yourself.