### PR TITLE
Fixes for dark default album art

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.sass-cache/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@
 		var style = $.sass('scss/', { style: 'compact', sourcemap: false });
 
 		return style
-			.on('error', function (error) { console.error('Error', err.message); })
+			.on('error', function (error) { console.error('Error', error.message); })
 			.pipe($.autoprefixer({ browsers: ['last 2 version'] }))
 			.pipe($.if(argv.prod, $.minifycss()))
 			.pipe(gulp.dest('css'))

--- a/scss/_playmidnight.scss
+++ b/scss/_playmidnight.scss
@@ -228,15 +228,19 @@ body {
 			color: $accent;
 		}
 	}
-
-	img[src$="default_artist_art.png"],
-	img[src$="default_album_art_big_card.png"],
-	img[src$="default_album_art_song_row.png"],
-	img[src$="default_album_med.png"] {
-		filter: invert(100%);
-	}
 }
 
+img[src$="default_artist_art.png"],
+img[src$="default_album_art_big_card.png"],
+img[src$="default_album_art_song_row.png"],
+img[src$="default_album_med.png"],
+.queue-details .empty-image {
+  filter: invert(100%);
+}
+
+.queue-details .fade {
+  z-index: 1;
+}
 
 // Sidebar/Nav
 .nav-item-container {


### PR DESCRIPTION
This fixes support for dark album art for places other than album cards, and also inverts the queue background when playing a song with no art. ([Before](http://i.imgur.com/tLi374d.png), [after](http://i.imgur.com/Puj2VYD.png))

Also included are a couple of unrelated fixes, which I can remove if you'd like.