### PR TITLE
Dark default album art & radio station card background

### DIFF
--- a/src/scss/_misc.scss
+++ b/src/scss/_misc.scss
@@ -153,3 +153,15 @@ iron-icon[icon="sj:unsubscribe"] svg {
 		fill: $font_primary;
 	}
 }
+
+// Default album art & radio station background
+img[src$="default_album.svg"],
+img[src$="default_playlist.svg"],
+img[src$="default_album_med.png"],
+img[src$="default_album_art_song_row.png"],
+.card[data-zoomable-image-url$="default_album.svg"] svg,
+.material-card[data-type="album"] svg.image,
+.material-card[data-type="wst"] .quilted-radio-fallback,
+.material-card[data-type="wst"] .quilted-radio-fallback > * {
+	filter: invert(100%);
+}


### PR DESCRIPTION
Looks like this feature got lost when Play Midnight got materialized.
(Coincidentally, PR #9 was just a little over a year ago.)

Let me know if it should go in a different file or if there was something I missed.
[Before](http://i.imgur.com/lLdVzsm.png), [after](http://i.imgur.com/4XAM00X.png)