### PR TITLE
Adding Prince purple color.

### DIFF
--- a/src/options.json
+++ b/src/options.json
@@ -61,6 +61,10 @@
                     {
                         "name": "Spartan Crimson",
                         "color": "#9d0000"
+                    },
+                    {
+                        "name": "Prince purple",
+                        "color": "#673ab7"
                     }
                 ],
                 "title": "Accent Colors",


### PR DESCRIPTION
Currently Google Music has as a default toolbar color #673ab7, because of paying tribute to Prince (see http://www.androidpolice.com/2016/04/22/google-pays-tribute-to-prince-colours-play-music-purple-and-designs-a-custom-google-doodle/). Maybe you could add it as one of the default colors.

![image](https://cloud.githubusercontent.com/assets/750954/14762612/ff7c909c-097e-11e6-95a5-a22f2cdce087.png)
