### PR TITLE
Accent fixes

### DIFF
--- a/src/scss/_accents.scss
+++ b/src/scss/_accents.scss
@@ -6,8 +6,8 @@
 }
 
 // Menu Selected
-.goog-menu .goog-menuitem.selected .goog-menuitem-content {
-	color: $color_accent;
+.goog-menu .goog-menuitem.selected .goog-menuitem-content:not([style-scope]):not(.style-scope) {
+	color: $color_accent !important;
 
 	&:hover {
 		color: $color_accent !important;
@@ -82,7 +82,7 @@ paper-button.material-primary:not([raised])[focused],
 }
 
 paper-action-dialog sj-paper-button,
-paper-dialog .buttons paper-button {
+paper-dialog .buttons paper-button:not([style-scope]):not(.style-scope):not([disabled]) {
 	color: $color_accent;
 }
 
@@ -92,7 +92,7 @@ paper-dialog .buttons paper-button {
 	color: $color_accent;
 }
 
-.more-songs-container {
+.more-songs-container.primary > paper-button {
 	color: $color_accent;
 }
 
@@ -187,7 +187,11 @@ paper-slider {
 	}
 }
 
-paper-slider #sliderKnobInner.paper-slider,
+paper-slider #sliderKnob.paper-slider.style-scope > #sliderKnobInner.paper-slider.style-scope {
+	background-color: $color_accent;
+	border: 2px solid $color_accent;
+}
+
 paper-progress #primaryProgress.paper-progress {
 	background-color: $color_accent;
 }
@@ -198,7 +202,7 @@ paper-progress #primaryProgress.paper-progress {
 }
 
 // Loading Overlay
-#loading-overlay.material paper-spinner .circle {
+#loading-overlay.material paper-spinner-lite .circle {
 	border-color: $color_accent;
 }
 
@@ -225,13 +229,14 @@ paper-spinner .spinner-layer {
 .explicit,
 .material-card .explicit,
 .material .song-row .explicit,
-.album-view .material-container-details .info .title .explicit {
+.album-view .material-container-details .info .title .explicit,
+.podcast-series-view .material-container-details .info .title .explicit {
 	background: $color_accent;
 }
 
 // Sidebar Navigation
-.nav-item-container,
-#nav_collections .nav-item-container, {
+a.nav-item-container.tooltip:not([style-scope]):not(.style-scope),
+#nav .nav-section > a.nav-item-container {
 	&.selected {
 		font-weight: 700;
 		color: $color_accent;
@@ -286,7 +291,7 @@ paper-slider::shadow #sliderBar::shadow #activeProgress {
 
 // Top Charts Colors
 .top-charts-view .song-row [data-col="index"] .content,
-.top-charts-view .song-row [data-col="index"] .column-content,
+.top-charts-view .song-row [data-col="index"] .column-content:not([style-scope]):not(.style-scope),
 .material-card .details .left-items .index {
 	color: $color_accent;
 }

--- a/src/scss/_cards.scss
+++ b/src/scss/_cards.scss
@@ -41,3 +41,8 @@
         background: linear-gradient( to right, rgba($background_card, 0) 0%, rgba($background_card, 0.999) 100% );
     }
 }
+
+// Songza cards
+.material-card[data-type="situations"][data-is-podlist-situation="true"] iron-icon.podcast-badge {
+    background-color: $background_card;
+}

--- a/src/scss/_menus.scss
+++ b/src/scss/_menus.scss
@@ -1,13 +1,19 @@
 paper-dialog {
     &::shadow {
-        h1,
-        .content {
+        h2,
+        .content,
+        .description,
+        .dialog-header .episode-title,
+        .dialog-header a[data-id="series-navigate"] {
             color: $font_primary;
         }
     }
 
-    h1,
-    .content {
+    h2,
+    .content,
+    .description,
+    .dialog-header .episode-title,
+    .dialog-header a[data-id="series-navigate"] {
         color: $font_primary;
     }
 }

--- a/src/scss/_misc.scss
+++ b/src/scss/_misc.scss
@@ -124,7 +124,8 @@ paper-dialog-scrollable.can-scroll:not([style-scope]):not(.style-scope):not(.scr
 .explicit,
 .material-card .explicit,
 .material .song-row .explicit,
-.album-view .material-container-details .info .title .explicit {
+.album-view .material-container-details .info .title .explicit,
+.podcast-series-view .material-container-details .info .title .explicit {
 	color: $background_card;
 }
 


### PR DESCRIPTION
My knowledge of CSS is severely lacking, so please let me know if any of this isn't kosher. I believe this PR should fix the following accent color issues: spinning progress bar overlay, all sidebar selected text, Top Charts, More Songs, progress/volume sliders, song list numbering. It also adds support for lots of podcast-related text/accents that weren't getting overridden.