### PR TITLE
Fix white bars in top charts

### DIFF
--- a/src/scss/_modal.scss
+++ b/src/scss/_modal.scss
@@ -156,7 +156,7 @@
     }
 
     .featured-header {
-      background: lighten($background_menu, 1%);
+      background: lighten($background_menu, 3%);
       padding: 10px;
 
       h1,

--- a/src/scss/_page.scss
+++ b/src/scss/_page.scss
@@ -35,7 +35,11 @@ $background_page_border: lighten($background_page, 2%);
 .material-detail-view .artist-details,
 .material-playlist-container,
 .situations-filter,
-.songlist-container {
+.songlist-container, 
+.song-table,
+.top-tracks-info,
+.more-songs-container,
+.gpm-vertical-list-0 #items.gpm-vertical-list {
   background: $background_page;
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -2,7 +2,7 @@ $color_accent: #fb8521;
 
 // Theme Colors
 $background_dark: #141517;
-$background_light: #dcdcdc;
+$background_light: #ececec;
 
 // App-Area Specific
 $background_nav: lighten($background_dark, 3%);
@@ -18,5 +18,5 @@ $border_menu: darken($background_menu, 5%);
 $border_search: darken($background_search, 3%);
 
 // Font Colors
-$font_primary: #dcdcdc;
+$font_primary: #ececec;
 $font_secondary: #888;


### PR DESCRIPTION
The Top charts/Browse stations section of Google Play Music isn't being themed properly. 

I've made adjustments that fixes this. I've also improved contrast for the header text in the "Music library". The text color change is visible in the browse stations at the top.

## Before

Top charts
![beforecharts](https://user-images.githubusercontent.com/10188094/31060808-b6a1c182-a6e7-11e7-9f1d-98af1760a1fe.png)

Browse stations
![beforestations](https://user-images.githubusercontent.com/10188094/31060811-c295af76-a6e7-11e7-95b7-fa3abbec552f.png)


## After

Top charts
![aftercharts](https://user-images.githubusercontent.com/10188094/31060815-c923eeac-a6e7-11e7-8b6d-00974bedbaa2.png)

Browse stations
![afterstations](https://user-images.githubusercontent.com/10188094/31060816-ce9ae2aa-a6e7-11e7-8604-2d7dc592440a.png)
