### PR TITLE
Super minor styling changes

### DIFF
--- a/src/scss/_player.scss
+++ b/src/scss/_player.scss
@@ -33,8 +33,7 @@ paper-slider::shadow .ring > #sliderKnob > #sliderKnobInner {
   cursor: not-allowed !important;
 }
 
-#player.material .material-player-middle paper-icon-button[data-id='play-pause'] iron-icon,
-#player.material .material-player-middle sj-icon-button[data-id='play-pause']::shadow core-icon {
+#player.material .material-player-middle paper-icon-button[data-id="play-pause"] iron-icon {
   g {
     path:nth-child(2) {
       fill: $background_player;

--- a/src/scss/_player.scss
+++ b/src/scss/_player.scss
@@ -12,6 +12,10 @@
   background: lighten($background_player, 5%);
 }
 
+#player:hover #material-player-progress:not([disabled]) #progressContainer {
+  background: transparent;
+}
+
 #material-player-left-wrapper #playerSongInfo #player-artist,
 #material-player-left-wrapper #playerSongInfo .player-album,
 #material-player-left-wrapper #playerSongInfo .player-dash {

--- a/src/scss/_song-table.scss
+++ b/src/scss/_song-table.scss
@@ -93,13 +93,14 @@ $background_page_zebra: lighten($background_page, 1%);
     &:hover {
       .column-content,
       .content,
-      .title-right-items,
+      .song-indicator,
       td {
         background-color: $background_page_hover !important;
       }
 
-      .song-indicator {
+      .title-right-items {
         background-color: $background_page_hover !important;
+        line-height: 39px;
       }
 
       .fade-out:after {


### PR DESCRIPTION
Just fixed up some super minor things that Google's messed up for whatever reason.

1. Play button is now black instead of white. (It used to be black until recently, this is just restoring it back.)

2. Song list used to extend by 1px when hovering over a row. (Check "Top charts" page or the queue for example)

3. Made song progress bar transparent to hide the gray that would show up on hover.